### PR TITLE
Fix incorrect rounding with BigDecimal

### DIFF
--- a/app/controllers/spree/api/retailops/orders_controller.rb
+++ b/app/controllers/spree/api/retailops/orders_controller.rb
@@ -169,7 +169,7 @@ module Spree
               end
 
               if lirec["estimated_unit_cost"]
-                cost = BigDecimal.new(lirec["estimated_unit_cost"].to_f, 2)
+                cost = BigDecimal.new(lirec["estimated_unit_cost"].to_f)
                 if cost > 0 and li.cost_price != cost
                   changed = true
                   li.update!(cost_price: cost)
@@ -177,7 +177,7 @@ module Spree
               end
 
               if lirec["unit_price"]
-                price = BigDecimal.new(lirec["unit_price"], 2)
+                price = BigDecimal.new(lirec["unit_price"])
                 if li.price != price
                   li.update!(price: price)
                   changed = true
@@ -195,8 +195,8 @@ module Spree
 
               if li.respond_to?(:retailops_extension_writeback)
                 # well-known extensions - known to ROP but not Spree
-                extra["direct_ship_amt"] = BigDecimal.new(lirec["direct_ship_amt"], 2) if lirec["direct_ship_amt"]
-                extra["apportioned_ship_amt"] = BigDecimal.new(lirec["apportioned_ship_amt"], 2) if lirec["apportioned_ship_amt"]
+                extra["direct_ship_amt"] = BigDecimal.new(lirec["direct_ship_amt"]) if lirec["direct_ship_amt"]
+                extra["apportioned_ship_amt"] = BigDecimal.new(lirec["apportioned_ship_amt"]) if lirec["apportioned_ship_amt"]
                 changed = true if li.retailops_extension_writeback(extra)
               end
 
@@ -210,15 +210,15 @@ module Spree
 
             if params["shipping_amt"]
               if order.respond_to?(:retailops_set_shipping_amt)
-                total = BigDecimal.new(params["shipping_amt"], 2)
-                item_level = BigDecimal.new(0,2) + params['line_items'].to_a.collect{ |l| BigDecimal.new(l['direct_ship_amt'], 2) }.sum
+                total = BigDecimal.new(params["shipping_amt"])
+                item_level = BigDecimal.new(0) + params['line_items'].to_a.collect{ |l| BigDecimal.new(l['direct_ship_amt']) }.sum
 
                 changed = true if order.retailops_set_shipping_amt(
                   total_shipping_amt: total,
                   order_shipping_amt: total - item_level
                 )
               else
-                changed = true if sync_shipping_amt order, BigDecimal.new(params["shipping_amt"], 2)
+                changed = true if sync_shipping_amt order, BigDecimal.new(params["shipping_amt"])
               end
             end
 
@@ -227,12 +227,12 @@ module Spree
             order.update! if changed
 
             if params["discount_amt"]
-              discount_amt = BigDecimal.new(params["discount_amt"],2)
+              discount_amt = BigDecimal.new(params["discount_amt"])
               changed = true if order.respond_to?(:retailops_set_order_discount_amount) ? order.retailops_set_order_discount_amount(discount_amt) : set_order_discount(order, discount_amt)
             end
 
             if params["tax_amt"]
-              tax_amt = BigDecimal.new(params["tax_amt"],2)
+              tax_amt = BigDecimal.new(params["tax_amt"])
               changed = true if order.respond_to?(:retailops_set_order_tax) ? order.retailops_set_order_tax(tax_amt) : set_order_tax(order, tax_amt)
             end
 
@@ -329,7 +329,7 @@ module Spree
             ret_obj = order.return_authorizations.detect { |r| r.number == ret_str }
 
             if ret_obj && ret_obj.received?
-              closed_value += BigDecimal.new(ret['refund_amt'],2) - (ret['tax_amt'] ? (BigDecimal.new(ret['tax_amt'],2) + BigDecimal.new(ret['shipping_amt'],2)) : 0)
+              closed_value += BigDecimal.new(ret['refund_amt']) - (ret['tax_amt'] ? (BigDecimal.new(ret['tax_amt']) + BigDecimal.new(ret['shipping_amt'])) : 0)
               ret["items"].to_a.each do |it|
                 it_obj = order.line_items.detect { |i| i.id.to_s == it["channel_refnum"].to_s }
                 closed_items[it_obj] = (closed_items[it_obj] || 0) + it["quantity"].to_i if it_obj
@@ -377,7 +377,7 @@ module Spree
 
           # set RMA amount
           if rma["subtotal_amt"].present? || rma["refund_amt"].present?
-            use_value = BigDecimal.new(rma['refund_amt'],2) - (rma['tax_amt'] ? (BigDecimal.new(rma['tax_amt'],2) + BigDecimal.new(rma['shipping_amt'],2)) : 0) - closed_value
+            use_value = BigDecimal.new(rma['refund_amt']) - (rma['tax_amt'] ? (BigDecimal.new(rma['tax_amt']) + BigDecimal.new(rma['shipping_amt'])) : 0) - closed_value
             if use_value != rma_obj.amount
               rma_obj.amount = use_value
               changed = true

--- a/app/controllers/spree/api/retailops/orders_controller.rb
+++ b/app/controllers/spree/api/retailops/orders_controller.rb
@@ -169,7 +169,7 @@ module Spree
               end
 
               if lirec["estimated_unit_cost"]
-                cost = BigDecimal.new(lirec["estimated_unit_cost"].to_f)
+                cost = BigDecimal.new(lirec["estimated_unit_cost"].to_s)
                 if cost > 0 and li.cost_price != cost
                   changed = true
                   li.update!(cost_price: cost)
@@ -177,7 +177,7 @@ module Spree
               end
 
               if lirec["unit_price"]
-                price = BigDecimal.new(lirec["unit_price"])
+                price = BigDecimal.new(lirec["unit_price"].to_s)
                 if li.price != price
                   li.update!(price: price)
                   changed = true
@@ -195,8 +195,8 @@ module Spree
 
               if li.respond_to?(:retailops_extension_writeback)
                 # well-known extensions - known to ROP but not Spree
-                extra["direct_ship_amt"] = BigDecimal.new(lirec["direct_ship_amt"]) if lirec["direct_ship_amt"]
-                extra["apportioned_ship_amt"] = BigDecimal.new(lirec["apportioned_ship_amt"]) if lirec["apportioned_ship_amt"]
+                extra["direct_ship_amt"] = BigDecimal.new(lirec["direct_ship_amt"].to_s) if lirec["direct_ship_amt"]
+                extra["apportioned_ship_amt"] = BigDecimal.new(lirec["apportioned_ship_amt"].to_s) if lirec["apportioned_ship_amt"]
                 changed = true if li.retailops_extension_writeback(extra)
               end
 
@@ -210,8 +210,8 @@ module Spree
 
             if params["shipping_amt"]
               if order.respond_to?(:retailops_set_shipping_amt)
-                total = BigDecimal.new(params["shipping_amt"])
-                item_level = BigDecimal.new(0) + params['line_items'].to_a.collect{ |l| BigDecimal.new(l['direct_ship_amt']) }.sum
+                total = BigDecimal.new(params["shipping_amt"].to_s)
+                item_level = BigDecimal.new(0) + params['line_items'].to_a.collect{ |l| BigDecimal.new(l['direct_ship_amt'].to_s) }.sum
 
                 changed = true if order.retailops_set_shipping_amt(
                   total_shipping_amt: total,
@@ -227,12 +227,12 @@ module Spree
             order.update! if changed
 
             if params["discount_amt"]
-              discount_amt = BigDecimal.new(params["discount_amt"])
+              discount_amt = BigDecimal.new(params["discount_amt"].to_s)
               changed = true if order.respond_to?(:retailops_set_order_discount_amount) ? order.retailops_set_order_discount_amount(discount_amt) : set_order_discount(order, discount_amt)
             end
 
             if params["tax_amt"]
-              tax_amt = BigDecimal.new(params["tax_amt"])
+              tax_amt = BigDecimal.new(params["tax_amt"].to_s)
               changed = true if order.respond_to?(:retailops_set_order_tax) ? order.retailops_set_order_tax(tax_amt) : set_order_tax(order, tax_amt)
             end
 
@@ -329,7 +329,7 @@ module Spree
             ret_obj = order.return_authorizations.detect { |r| r.number == ret_str }
 
             if ret_obj && ret_obj.received?
-              closed_value += BigDecimal.new(ret['refund_amt']) - (ret['tax_amt'] ? (BigDecimal.new(ret['tax_amt']) + BigDecimal.new(ret['shipping_amt'])) : 0)
+              closed_value += BigDecimal.new(ret['refund_amt'].to_s) - (ret['tax_amt'] ? (BigDecimal.new(ret['tax_amt'].to_s) + BigDecimal.new(ret['shipping_amt'].to_s)) : 0)
               ret["items"].to_a.each do |it|
                 it_obj = order.line_items.detect { |i| i.id.to_s == it["channel_refnum"].to_s }
                 closed_items[it_obj] = (closed_items[it_obj] || 0) + it["quantity"].to_i if it_obj
@@ -377,7 +377,7 @@ module Spree
 
           # set RMA amount
           if rma["subtotal_amt"].present? || rma["refund_amt"].present?
-            use_value = BigDecimal.new(rma['refund_amt']) - (rma['tax_amt'] ? (BigDecimal.new(rma['tax_amt']) + BigDecimal.new(rma['shipping_amt'])) : 0) - closed_value
+            use_value = BigDecimal.new(rma['refund_amt'].to_s) - (rma['tax_amt'] ? (BigDecimal.new(rma['tax_amt'].to_s) + BigDecimal.new(rma['shipping_amt'].to_s)) : 0) - closed_value
             if use_value != rma_obj.amount
               rma_obj.amount = use_value
               changed = true

--- a/app/controllers/spree/api/retailops/settlement_controller.rb
+++ b/app/controllers/spree/api/retailops/settlement_controller.rb
@@ -256,7 +256,7 @@ module Spree
 
             # set value
             # these might come in as strings, so coerce *before* summing
-            return_obj.amount = BigDecimal.new(info['refund_amt'],2) - (info['tax_amt'] ? (BigDecimal.new(info['tax_amt'],2) + BigDecimal.new(info['shipping_amt'],2)) : 0)
+            return_obj.amount = BigDecimal.new(info['refund_amt']) - (info['tax_amt'] ? (BigDecimal.new(info['tax_amt']) + BigDecimal.new(info['shipping_amt'])) : 0)
             return_obj.save!
 
             # receive it
@@ -269,8 +269,8 @@ module Spree
             # Possible issue: Setting "Refund" = No for an item will be treated the same as nulling the refund with a restocking fee
 
             if info['tax_amt']
-              shipping_amt = BigDecimal.new(info['shipping_amt'],2)
-              tax_amt = BigDecimal.new(info['tax_amt'],2)
+              shipping_amt = BigDecimal.new(info['shipping_amt'])
+              tax_amt = BigDecimal.new(info['tax_amt'])
 
               @order.adjustments.create!(amount: -shipping_amt, label: "Return #{rop_return_id} Shipping") if shipping_amt.nonzero?
               @order.adjustments.create!(amount: -tax_amt, label: "Return #{rop_return_id} Tax") if tax_amt.nonzero?

--- a/app/controllers/spree/api/retailops/settlement_controller.rb
+++ b/app/controllers/spree/api/retailops/settlement_controller.rb
@@ -256,7 +256,7 @@ module Spree
 
             # set value
             # these might come in as strings, so coerce *before* summing
-            return_obj.amount = BigDecimal.new(info['refund_amt'].to_S) - (info['tax_amt'] ? (BigDecimal.new(info['tax_amt'].to_s) + BigDecimal.new(info['shipping_amt'].to_s)) : 0)
+            return_obj.amount = BigDecimal.new(info['refund_amt'].to_s) - (info['tax_amt'] ? (BigDecimal.new(info['tax_amt'].to_s) + BigDecimal.new(info['shipping_amt'].to_s)) : 0)
             return_obj.save!
 
             # receive it

--- a/app/controllers/spree/api/retailops/settlement_controller.rb
+++ b/app/controllers/spree/api/retailops/settlement_controller.rb
@@ -256,7 +256,7 @@ module Spree
 
             # set value
             # these might come in as strings, so coerce *before* summing
-            return_obj.amount = BigDecimal.new(info['refund_amt']) - (info['tax_amt'] ? (BigDecimal.new(info['tax_amt']) + BigDecimal.new(info['shipping_amt'])) : 0)
+            return_obj.amount = BigDecimal.new(info['refund_amt'].to_S) - (info['tax_amt'] ? (BigDecimal.new(info['tax_amt'].to_s) + BigDecimal.new(info['shipping_amt'].to_s)) : 0)
             return_obj.save!
 
             # receive it
@@ -269,8 +269,8 @@ module Spree
             # Possible issue: Setting "Refund" = No for an item will be treated the same as nulling the refund with a restocking fee
 
             if info['tax_amt']
-              shipping_amt = BigDecimal.new(info['shipping_amt'])
-              tax_amt = BigDecimal.new(info['tax_amt'])
+              shipping_amt = BigDecimal.new(info['shipping_amt'].to_s)
+              tax_amt = BigDecimal.new(info['tax_amt'].to_s)
 
               @order.adjustments.create!(amount: -shipping_amt, label: "Return #{rop_return_id} Shipping") if shipping_amt.nonzero?
               @order.adjustments.create!(amount: -tax_amt, label: "Return #{rop_return_id} Tax") if tax_amt.nonzero?


### PR DESCRIPTION

It looks you are passing 2 as the second argument to BigDecimal in attempt to round to two decimal places. But in-fact this causes rounding to two significant digits. 

```ruby
[1] pry(main)> n = BigDecimal(12345.67, 2)
=> #<BigDecimal:10c4c9b60,'0.12E5',9(27)>
[2] pry(main)> n.to_s
=> "12000.0"
[3] pry(main)> n == 12345.67
=> false
[4] pry(main)> n == 12345
=> false
[5] pry(main)> n == 12000
=> true
```

You can round BigDecimal using 

```ruby
      BigDecimal.new(amount.to_s).round(2, BigDecimal::ROUND_HALF_UP)
```

