### PR TITLE
Ensure `order` is Set on Adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,4 +48,6 @@ I'm a hard-liner about namespace pollution, so all global names created or inter
 
 * `Spree::LineItem#retailops_extension_writeback(hash)`: Define this to accept per-line-item data which is not handled by stock Spree.  Two hash keys are currently defined, `direct_ship_amt` which is a BigDecimal shipping amount for the specific line item (not including order-wide shipping charges), and `apportioned_ship_amt` which is that line item's share of the order shipping (as would be used for refunds).
 
+* `Spree::LineItem#retailops_expected_ship_date`: Define this to automatically populate the RetailOps "expected ship date" field on order line items, allowing for customer expectation-based routing decisions.
+
 Copyright (c) 2014 Gud Technologies, Inc, released under the New BSD License

--- a/app/controllers/spree/api/retailops/orders_controller.rb
+++ b/app/controllers/spree/api/retailops/orders_controller.rb
@@ -329,7 +329,7 @@ module Spree
             ret_obj = order.return_authorizations.detect { |r| r.number == ret_str }
 
             if ret_obj && ret_obj.received?
-              closed_value += BigDecimal.new(ret["subtotal_amt"] || ret["refund_amt"],2)
+              closed_value += BigDecimal.new(ret['refund_amt'],2) - (ret['tax_amt'] ? (BigDecimal.new(ret['tax_amt'],2) + BigDecimal.new(ret['shipping_amt'],2)) : 0)
               ret["items"].to_a.each do |it|
                 it_obj = order.line_items.detect { |i| i.id.to_s == it["channel_refnum"].to_s }
                 closed_items[it_obj] = (closed_items[it_obj] || 0) + it["quantity"].to_i if it_obj
@@ -377,7 +377,7 @@ module Spree
 
           # set RMA amount
           if rma["subtotal_amt"].present? || rma["refund_amt"].present?
-            use_value = BigDecimal.new(rma["subtotal_amt"] || rma["refund_amt"],2) - closed_value
+            use_value = BigDecimal.new(rma['refund_amt'],2) - (rma['tax_amt'] ? (BigDecimal.new(rma['tax_amt'],2) + BigDecimal.new(rma['shipping_amt'],2)) : 0) - closed_value
             if use_value != rma_obj.amount
               rma_obj.amount = use_value
               changed = true

--- a/app/controllers/spree/api/retailops/orders_controller.rb
+++ b/app/controllers/spree/api/retailops/orders_controller.rb
@@ -34,6 +34,7 @@ module Spree
           use_association LineItem, [:adjustments]
           ad_hoc(LineItem, :sku, [:variant]) { |i| i.variant.try(:sku) }
           ad_hoc(LineItem, :advisory, [:variant]) { |i| p = i.variant.try(:product); i.try(:retailops_is_advisory?) || p.try(:retailops_is_advisory?) || p.try(:is_gift_card) }
+          ad_hoc(LineItem, :expected_ship_date, []) { |i| i.try(:retailops_expected_ship_date) }
 
           use_association Variant, [:product], false
 

--- a/app/controllers/spree/api/retailops/orders_controller.rb
+++ b/app/controllers/spree/api/retailops/orders_controller.rb
@@ -329,7 +329,7 @@ module Spree
             ret_obj = order.return_authorizations.detect { |r| r.number == ret_str }
 
             if ret_obj && ret_obj.received?
-              closed_value += BigDecimal.new(ret["refund_amt"],2)
+              closed_value += BigDecimal.new(ret["subtotal_amt"] || ret["refund_amt"],2)
               ret["items"].to_a.each do |it|
                 it_obj = order.line_items.detect { |i| i.id.to_s == it["channel_refnum"].to_s }
                 closed_items[it_obj] = (closed_items[it_obj] || 0) + it["quantity"].to_i if it_obj
@@ -376,8 +376,8 @@ module Spree
           end
 
           # set RMA amount
-          if rma["refund_amt"].present?
-            use_value = BigDecimal.new(rma["refund_amt"],2) - closed_value
+          if rma["subtotal_amt"].present? || rma["refund_amt"].present?
+            use_value = BigDecimal.new(rma["subtotal_amt"] || rma["refund_amt"],2) - closed_value
             if use_value != rma_obj.amount
               rma_obj.amount = use_value
               changed = true
@@ -387,6 +387,11 @@ module Spree
           rma_obj.save! if changed
           return true
         end
+
+        private
+          def options
+            params['options'] || {}
+          end
       end
     end
   end

--- a/app/controllers/spree/api/retailops/orders_controller.rb
+++ b/app/controllers/spree/api/retailops/orders_controller.rb
@@ -258,6 +258,7 @@ module Spree
           }.to_json
         end
 
+        # http://help.retailops.com/hc/en-us/articles/206379093
         def sync_rma(order, rma)
           # This is half of the RMA/return push mechanism: it handles RMAs created in RetailOps by
           # creating matching RMAs in Spree numbered RMA-ROP-NNN.  Any inventory which has been

--- a/app/controllers/spree/api/retailops/orders_controller.rb
+++ b/app/controllers/spree/api/retailops/orders_controller.rb
@@ -297,10 +297,12 @@ module Spree
                 end
                 cust_return.return_items = spree_return_items.flatten!
                 cust_return.save
-                #reject the items if the refund amount is 0
-                #This should mean that we have recieved the item, but don't want to issue a refund.
+
+                # Require Manual Intervention if the items if the refund amount is 0. A 0 here
+                # means that the item was received but we cannot resell it. It's possible we should
+                # still issue a refund here, for example if the customer received the item damaged.
                 if ret['refund_amt'].to_i == 0
-                  spree_return_items.each{|sri| sri.reject}
+                  spree_return_items.each { |sri| sri.require_manual_intervention }
                 end
               end
             end

--- a/app/controllers/spree/api/retailops/orders_controller.rb
+++ b/app/controllers/spree/api/retailops/orders_controller.rb
@@ -275,7 +275,7 @@ module Spree
 
           if rop_amt != apparent_amt
             changed = true
-            adj ||= order.adjustments.create(amount: rop_amt - apparent_amt, label: label, mandatory: false)
+            adj ||= order.adjustments.create(order: order, amount: rop_amt - apparent_amt, label: label, mandatory: false)
             adj.amount = rop_amt - apparent_amt
             adj.save!
           end
@@ -298,7 +298,7 @@ module Spree
 
           if adj_amt != amt
             changed = true
-            adj ||= order.adjustments.create(amount: amt, label: "Standard Shipping", mandatory: false)
+            adj ||= order.adjustments.create(order: order, amount: amt, label: "Standard Shipping", mandatory: false)
             adj.amount = amt
             adj.save!
           end

--- a/app/controllers/spree/api/retailops/settlement_controller.rb
+++ b/app/controllers/spree/api/retailops/settlement_controller.rb
@@ -138,11 +138,11 @@ module Spree
             shipment.state = 'ready'
             shipment.ship!
             shipment.save!
-            
+
             @order.shipments.reload
-            @order.shipments.each do |s| 
-                s.reload 
-                s.destroy! if s.manifest.empty? 
+            @order.shipments.each do |s|
+                s.reload
+                s.destroy! if s.manifest.empty?
             end
             @order.reload
             @order.update!

--- a/app/controllers/spree/api/retailops/settlement_controller.rb
+++ b/app/controllers/spree/api/retailops/settlement_controller.rb
@@ -73,7 +73,8 @@ module Spree
                 return_items << ri if ri.variant.sku == rops_ri['sku']
               end
             end
-            reibursement = Spree::Reimbursement.create(order: order, customer_return: spree_return, return_items: return_items, total: params['settlement']["refund_amt"].to_f)
+            reimbursement_total = BigDecimal.new(params['settlement']["refund_amt"])
+            reibursement = Spree::Reimbursement.create(order: order, customer_return: spree_return, return_items: return_items, total: reimbursement_total)
           end
           render text: "".to_json
         end

--- a/app/controllers/spree/api/retailops/settlement_controller.rb
+++ b/app/controllers/spree/api/retailops/settlement_controller.rb
@@ -272,8 +272,8 @@ module Spree
               shipping_amt = BigDecimal.new(info['shipping_amt'],2)
               tax_amt = BigDecimal.new(info['tax_amt'],2)
 
-              @order.adjustments.create!(amount: -shipping_amt, label: "Return #{rop_return_id} Shipping") if shipping_amt.nonzero?
-              @order.adjustments.create!(amount: -tax_amt, label: "Return #{rop_return_id} Tax") if tax_amt.nonzero?
+              @order.adjustments.create!(order: @order, amount: -shipping_amt, label: "Return #{rop_return_id} Shipping") if shipping_amt.nonzero?
+              @order.adjustments.create!(order: @order, amount: -tax_amt, label: "Return #{rop_return_id} Tax") if tax_amt.nonzero?
             end
           end
 

--- a/lib/spree/retailops/rop_order_helper.rb
+++ b/lib/spree/retailops/rop_order_helper.rb
@@ -33,7 +33,7 @@ module Spree
 
         if extracted_total > 0
           # TODO: is Standard Shipping the best name for this?  Should i18n happen?
-          @order.adjustments.create(amount: extracted_total, label: "Standard Shipping", mandatory: false)
+          @order.adjustments.create(order: @order, amount: extracted_total, label: "Standard Shipping", mandatory: false)
           @order.save!
           changed = true
         end

--- a/lib/spree/retailops/rop_order_helper.rb
+++ b/lib/spree/retailops/rop_order_helper.rb
@@ -4,6 +4,8 @@ module Spree
       attr_accessor :order, :options
 
       def standard_shipping_label
+        # This label is recognized in Huckberry app/models/spree/order_decorator#true_ship_total
+        # If it changes need to update there.
         'Standard Shipping'
       end
 


### PR DESCRIPTION
This address an issue with the RetailOps Spree extension and Spree 2.4. In Spree 2.4, the `order` of an `Spree::Adjustment` became a required attribute, but the extension was only setting the `adjustable` attribute of an adjustment. This pull request explicitly sets the `order` in every place the extension is creating an adjustment on a `Spree::Order`.

This is currently in production for us, and has been for 2 days. However, we have not tested this with versions of Spree prior to 2.4. However, based on [this migration added late last year][migration] and [this other migration from August 2013][order_id_migration] it seems like this should work back to Spree 2.2.

[migration]: https://github.com/spree/spree/commit/d6c18fcd5774b624bef4e0684af4d7910b9dff1a
[order_id_migration]: https://github.com/spree/spree/commit/0b64980df9138493c6e30c44ba962c6e76cb6840