### PR TITLE
- Moves calls to update li.estimated_ship_date from separate if blocks to combined if/elsif block to avoid needlessly setting this value twice.

### DIFF
--- a/app/controllers/spree/api/retailops/orders_controller.rb
+++ b/app/controllers/spree/api/retailops/orders_controller.rb
@@ -189,14 +189,13 @@ module Spree
                 end
               end
 
-              if li.respond_to?(:estimated_ship_date=) && li.estimated_ship_date != eshp
+              if li.respond_to?(:retailops_set_estimated_ship_date)
+                changed = true if li.retailops_set_estimated_ship_date(eshp)
+              elsif li.respond_to?(:estimated_ship_date=) && li.estimated_ship_date != eshp
                 changed = true
                 li.update!(estimated_ship_date: eshp)
               end
 
-              if li.respond_to?(:retailops_set_estimated_ship_date)
-                changed = true if li.retailops_set_estimated_ship_date(eshp)
-              end
 
               if li.respond_to?(:retailops_extension_writeback)
                 # well-known extensions - known to ROP but not Spree


### PR DESCRIPTION
This is a change we found necessary in our repo since we have an after_update hook on line items. We did not want to fire this hook twice, hence this change.

I do not believe this will create problems for other users of the repo since the ultimate value for line_item.estimated_ship_date is the same before and after this change.
