### PR TITLE
Allow Custom Handling for Reimbursements and RMAs

### DIFF
--- a/spree_retailops.gemspec
+++ b/spree_retailops.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_retailops'
-  s.version     = '2.2.1'
+  s.version     = '2.3.0'
   s.summary     = 'Spree extension to allow PIM and OMS integration from RetailOps'
   s.description = 'Spree extension to allow PIM and OMS integration from RetailOps'
   s.required_ruby_version = '>= 1.9.3'
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  #s.add_dependency 'spree_core', '~> 2.2.1'
+  s.add_dependency 'spree_core', '>= 2.4.6'
 
   s.add_development_dependency 'capybara', '~> 2.1'
   s.add_development_dependency 'coffee-rails'


### PR DESCRIPTION
This represents work that I have done for our client, Huckberry, to allow the host application to customize the logic for reimbursements and RMAs sent from ROPs to Spree. Both follow the same pattern of implementation; they check for the definition of a service object, then call out to it if defined.

This also bumps the MINOR version number to reflect non-breaking feature adds, and adds a dependency for Spree 2.4, which is the only version we have tested this on.